### PR TITLE
Decode configuration files from UTF-8

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ from glob import glob
 import logging
 import os
 import pdb
+from codecs import open
 from site import main as refresh_pythonpath
 import sys
 
@@ -153,7 +154,7 @@ class BaseApplication(object):
     def read_file(self, parser, filename):
         logger.debug('Reading %s.', filename)
         try:
-            with open(filename, 'r') as fp:
+            with open(filename, 'r', 'utf-8') as fp:
                 parser.readfp(fp)
         except IOError as e:
             raise UserError(str(e))

--- a/taskmanager.py
+++ b/taskmanager.py
@@ -625,8 +625,8 @@ class Scheduler(object):
                 continue
 
         for task_id in remove_list:
-                logger.debug("Removing Task %s" % task_id)
-                self.task_list.rm(task_id)
+            logger.debug("Removing Task %s" % task_id)
+            self.task_list.rm(task_id)
 
     def handle_message(self, message):
         if message.type == MSG_TYPE_TASK_NEW:


### PR DESCRIPTION
Fixes:

    ERROR:   File "/usr/lib/python2.7/dist-packages/backports/configparser/__init__.py", line 1052, in _read
    ERROR:     if line.strip().startswith(prefix):
    ERROR: UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 12: ordinal not in range(128)

cf. https://github.com/dalibo/temboard-agent/issues/356