### PR TITLE
proctitle: Remove only python's -c

### DIFF
--- a/proctitle.py
+++ b/proctitle.py
@@ -75,7 +75,7 @@ def fix_argv(argv):
     return argv
 
 
-def find_argv_memory_from_pythonapi():
+def find_argv_memory_from_pythonapi():  # pragma: nocover
     """ Return pointer and size of argv memory segment. """
     # This implemententation works only on Python2. cf.
     # http://docs.cherrypy.org/en/latest/_modules/cherrypy/process/wspbus.html
@@ -169,7 +169,7 @@ class ProcTitleManager(object):
         self.prefix = prefix
         self.address = self.size = None
 
-    def setup(self):
+    def setup(self):  # pragma: nocover
         try:
             argv, self.address, self.size = find_argv_memory_from_pythonapi()
             if sys.version_info > (2,):  # pragma: nocover_py2

--- a/tests/test_proctitle.py
+++ b/tests/test_proctitle.py
@@ -33,6 +33,9 @@ def test_fix_argv(mocker):
     wanted = ['python', 'my-script.py']
     assert wanted == fix_argv(['python', 'my-script.py'])
 
+    wanted = ['python', 'my-script.py', '-c', 'config']
+    assert wanted == fix_argv(['python', '-c', 'my-script.py', '-c', 'config'])
+
 
 def test_read_memory():
     import ctypes


### PR DESCRIPTION
This fixes removing of -c argument from script like `temboard -c temboard.conf`.

Fixes:

    DEBUG: Failed to find argv memory segment: Can't find argv in stack segment