### PR TITLE
Wrap error in a serializable one

### DIFF
--- a/taskmanager.py
+++ b/taskmanager.py
@@ -886,6 +886,7 @@ class WorkerPool(object):
             # Put function result into output queue as a Message
             out.put(Message(MSG_TYPE_RESP, res))
         except Exception as e:
+            e = Exception("%s: %s" % (type(e), e))
             out.put(Message(MSG_TYPE_ERROR, e))
             logger.exception(e)
         except KeyboardInterrupt:


### PR DESCRIPTION
Fixes:

    ERROR:   File "/usr/lib64/python2.7/multiprocessing/queues.py", line 135, in get
    ERROR:     res = self._recv()
    ERROR: TypeError: ('__init__() takes exactly 3 arguments (2 given)', <class 'temboard...'>, ('...',))