### PR TITLE
Fix a TypeError in ServicesManager.kill()

### DIFF
--- a/services.py
+++ b/services.py
@@ -206,6 +206,6 @@ class ServicesManager(object):
             sleep(step)
             timeout -= step
 
-        for _, process in processes:
+        for process in processes:
             logger.warning(u"Killing %s.", process)
             os.kill(process.pid, signal.SIGKILL)


### PR DESCRIPTION
The 'processes' list contains Process objects, which are not iterable.

Spotted by pytype:

    File ".../toolkit/services.py", line 209, in kill: No attribute '__iter__' on multiprocessing.context.Process [attribute-error]